### PR TITLE
fixing port already in use bug

### DIFF
--- a/modes/from-source/docker-compose.yml
+++ b/modes/from-source/docker-compose.yml
@@ -335,7 +335,7 @@ services:
       /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb myminio/avatar-images;
       /usr/bin/mc anonymous set download myminio/avatar-images;
-
+      exit 0;
       "
 
   caddy:

--- a/modes/from-source/docker-compose.yml
+++ b/modes/from-source/docker-compose.yml
@@ -308,7 +308,7 @@ services:
     networks:
       - internal
     ports:
-      - 9000
+      - 9000:9000
       - 9090
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:9090"]
@@ -322,7 +322,7 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_ADDRESS: 0.0.0.0:9000
-    command: server /export  --console-address 0.0.0.0:9090
+    command: server --console-address 0.0.0.0:9090 /export
 
   minio-init:
     image: minio/mc

--- a/modes/from-source/docker-compose.yml
+++ b/modes/from-source/docker-compose.yml
@@ -308,8 +308,8 @@ services:
     networks:
       - internal
     ports:
-      - 9000:9000
-      - 9090:9090
+      - 9000
+      - 9090
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:9090"]
       interval: 10s
@@ -335,7 +335,7 @@ services:
       /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb myminio/avatar-images;
       /usr/bin/mc anonymous set download myminio/avatar-images;
-      exit 0;
+
       "
 
   caddy:


### PR DESCRIPTION
Fixing the following intermittendly appearing error on startup:

`Error response from daemon: driver failed programming external connectivity on endpoint from-source-minio-1 (c5a2c55069188a0bbfa934d4fe92c4eec5578e9dade91253a22dd4d7bad67d2b): Bind for 0.0.0.0:9090 failed: port is already allocated`